### PR TITLE
fix golang for multi-arch builds

### DIFF
--- a/.github/workflows/call-docker-build-api.yaml
+++ b/.github/workflows/call-docker-build-api.yaml
@@ -48,5 +48,5 @@ jobs:
       image-names: |
         bretfisher/wordsmith-api
         ghcr.io/bretfisher/wordsmith-api
-      context: api
+      context: "{{defaultContext}}:api"
       platforms: linux/amd64,linux/arm64

--- a/.github/workflows/call-docker-build-api.yaml
+++ b/.github/workflows/call-docker-build-api.yaml
@@ -38,54 +38,15 @@ jobs:
       pull-requests: write # needed to create and update comments in PRs
     
     secrets:
-
-      # Only needed if with:dockerhub-enable is true below
       dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
-
-      # Only needed if with:dockerhub-enable is true below
       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
     with:
       
-      ### REQUIRED
-      ### ENABLE ONE OR BOTH REGISTRIES
-      ### tell docker where to push.
-      ### NOTE if Docker Hub is set to true, you must set secrets above and also add account/repo/tags below
       dockerhub-enable: true
       ghcr-enable: true
-
-      ### REQUIRED 
-      ### A list of the account/repo names for docker build. List should match what's enabled above
-      ### defaults to:
       image-names: |
         bretfisher/wordsmith-api
         ghcr.io/bretfisher/wordsmith-api
-
-      ### REQUIRED set rules for tagging images, based on special action syntax:
-      ### https://github.com/docker/metadata-action#tags-input
-      ### defaults to:
-      tag-rules: |
-        type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
-        type=ref,event=pr
-        type=ref,event=branch
-        type=semver,pattern={{version}}
-        type=raw,value=gha-${{ github.run_id }}
-      
-      ### path to where docker should copy files into image
-      ### defaults to root of repository (.)
       context: api
-      
-      ### Dockerfile alternate name. Default is Dockerfile (relative to context path)
-      # file: Containerfile
-
-      ### build stage to target, defaults to empty, which builds to last stage in Dockerfile
-      # target:
-      
-      ### platforms to build for, defaults to linux/amd64
-      ### other options: linux/amd64,linux/arm64,linux/arm/v7
-      #FIXME: sadly arm/v7 isn't stable in Java land
       platforms: linux/amd64,linux/arm64
-      
-      ### Create a PR comment with image tags and labels
-      ### defaults to false
-      # comment-enable: false

--- a/.github/workflows/call-docker-build-web.yaml
+++ b/.github/workflows/call-docker-build-web.yaml
@@ -47,5 +47,5 @@ jobs:
       image-names: |
         bretfisher/wordsmith-web
         ghcr.io/bretfisher/wordsmith-web
-      context: web
+      context: "{{defaultContext}}:web"
       platforms: linux/amd64,linux/arm64

--- a/.github/workflows/call-docker-build-web.yaml
+++ b/.github/workflows/call-docker-build-web.yaml
@@ -1,6 +1,5 @@
 name: Build Web
 
-# Controls when the action will run. 
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
@@ -38,53 +37,15 @@ jobs:
       pull-requests: write # needed to create and update comments in PRs
     
     secrets:
-
-      # Only needed if with:dockerhub-enable is true below
       dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
-
-      # Only needed if with:dockerhub-enable is true below
       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
     with:
       
-      ### REQUIRED
-      ### ENABLE ONE OR BOTH REGISTRIES
-      ### tell docker where to push.
-      ### NOTE if Docker Hub is set to true, you must set secrets above and also add account/repo/tags below
       dockerhub-enable: true
       ghcr-enable: true
-
-      ### REQUIRED 
-      ### A list of the account/repo names for docker build. List should match what's enabled above
-      ### defaults to:
       image-names: |
         bretfisher/wordsmith-web
         ghcr.io/bretfisher/wordsmith-web
-
-      ### REQUIRED set rules for tagging images, based on special action syntax:
-      ### https://github.com/docker/metadata-action#tags-input
-      ### defaults to:
-      tag-rules: |
-        type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
-        type=ref,event=pr
-        type=ref,event=branch
-        type=semver,pattern={{version}}
-        type=raw,value=gha-${{ github.run_id }}
-      
-      ### path to where docker should copy files into image
-      ### defaults to root of repository (.)
       context: web
-      
-      ### Dockerfile alternate name. Default is Dockerfile (relative to context path)
-      # file: Containerfile
-
-      ### build stage to target, defaults to empty, which builds to last stage in Dockerfile
-      # target:
-      
-      ### platforms to build for, defaults to linux/amd64
-      ### other options: linux/amd64,linux/arm64,linux/arm/v7
-      platforms: linux/amd64,linux/arm64,linux/arm/v7
-      
-      ### Create a PR comment with image tags and labels
-      ### defaults to false
-      # comment-enable: false
+      platforms: linux/amd64,linux/arm64

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -10,10 +10,10 @@ RUN GOOS=linux GOARCH=$TARGETARCH go build dispatcher.go
 
 # RUN
 # defaults to using the target arch image
-FROM alpine
+FROM scratch as run
 
 EXPOSE 80
 CMD ["/dispatcher"]
 
-COPY --from=builder /go/dispatcher /
+COPY --from=builder /go/dispatcher /dispatcher
 COPY static /static/

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,10 +1,15 @@
 # BUILD
-FROM golang:alpine as builder
+# use the build platforms matching arch rather than target arch
+FROM --platform=$BUILDPLATFORM golang:alpine as builder
+
+ARG TARGETARCH
 
 COPY dispatcher.go .
-RUN go build dispatcher.go
+# build for the target arch not the build platform host arch
+RUN GOOS=linux GOARCH=$TARGETARCH go build dispatcher.go
 
 # RUN
+# defaults to using the target arch image
 FROM alpine
 
 EXPOSE 80

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -4,6 +4,8 @@ FROM --platform=$BUILDPLATFORM golang:alpine as builder
 
 ARG TARGETARCH
 
+WORKDIR /go
+
 COPY dispatcher.go .
 # build for the target arch not the build platform host arch
 RUN GOOS=linux GOARCH=$TARGETARCH go build dispatcher.go
@@ -15,5 +17,5 @@ FROM scratch as run
 EXPOSE 80
 CMD ["/dispatcher"]
 
-COPY --from=builder /go/dispatcher /dispatcher
+COPY --from=builder /go/dispatcher /
 COPY static /static/


### PR DESCRIPTION
Ideally, we want golang to build without QEMU. This PR ensures:

1. the image we build on matches the host platform/architecture
2. the binary we build matches the target run platform
3. the image we run from matches the architecture of the binary we built